### PR TITLE
usbctl: fix usage message

### DIFF
--- a/usbctl
+++ b/usbctl
@@ -9,8 +9,8 @@ usage() {
 	echo "Control to deny new usb devices."
 	echo
 	echo "Available commands:"
-	echo "  protect       disable protection against new usb devices"
-	echo "  unprotect     enable protection against new usb devices"
+	echo "  protect       enable protection against new usb devices"
+	echo "  unprotect     disable protection against new usb devices"
 	echo "  temporary     temporarily disable protection (default 10 sec)"
 	echo "  check         exits with 1 if usb is unprotected"
 	echo "  status        print current protection status"


### PR DESCRIPTION
~~Assuming that the following behavior is intended:~~

    on = protect = enable = deny_new_usb 1
    off = unprotect = disable = deny_new_usb 0

Edit: Fix just the usage message.