### PR TITLE
added manpage for usbctl

### DIFF
--- a/doc/usbctl.1
+++ b/doc/usbctl.1
@@ -1,0 +1,53 @@
+
+.TH "USBCTL" "1" "07/24/2018" "1.1" "usbctl manual"
+.SH "NAME"
+usbctl \- Linux-hardened deny_new_usb control
+.SH "SYNOPSIS"
+\fBusbctl\fR \fI[COMMAND]\fR
+.SH "DESCRIPTION"
+Control usb device and protection settings.
+.SH "COMMANDS"
+.PP 
+\fIprotect\fR, \fIdisable\fR, \fIoff\fR
+.RS 4
+disallow new usb devices (protected)
+.RE
+.PP 
+\fIunprotect\fR, \fIenable\fR, \fIon\fR
+.RS 4
+allow new usb devices (unprotected)
+.RE
+.PP 
+\fItemporary\fR, \fItemp\fR, \fItmp\fR
+.RS 4
+temporarily disable protection (default 60 sec)
+.RE
+.PP 
+\fIcheck\fR
+.RS 4
+exit with 1 if usb is unprotected
+.RE
+.PP 
+\fIstatus\fR
+.RS 4
+print current protection status
+.RE
+.PP 
+\fIlist\fR, \fIls\fR
+.RS 4
+list currently connected usb devices
+.RE
+.PP 
+\fIlog\fR
+.RS 4
+display usb events in the kernel ring buffer
+.RE
+.PP 
+\fIversion\fR
+.RS 4
+display version information and exit
+.RE
+.SH "AUTHORS"
+Levente Polyak
+.RE
+kpcyrd


### PR DESCRIPTION
This commit adds a manpage for `usbctl`. You can preview it with `man ./usbctl.1`