### PR TITLE
Start systemd service depending on deny_new_usb availability

### DIFF
--- a/contrib/systemd/deny-new-usb.service
+++ b/contrib/systemd/deny-new-usb.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=deny new usb devices
+ConditionFileNotEmpty=/proc/sys/kernel/deny_new_usb
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
contrib/systemd/deny-new-usb.service: Adding ConditionFileNotEmpty for /proc/sys/kernel/deny_new_usb to not fail on non-hardened kernels.
Closes #6 