### PR TITLE
Using ConditionPathExists instead of ConditionFileNotEmpty for systemd unit

### DIFF
--- a/contrib/systemd/deny-new-usb.service
+++ b/contrib/systemd/deny-new-usb.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=deny new usb devices
-ConditionFileNotEmpty=/proc/sys/kernel/deny_new_usb
+ConditionPathExists=/proc/sys/kernel/deny_new_usb
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
contrib/systemd/deny-new-usb.service: Switching to ConditionPathExists for /proc/sys/kernel/deny_new_usb discovery, as ConditionFileNotEmpty is always false (due to /proc).