### PR TITLE
Allow passing time to temporary, default 60

### DIFF
--- a/doc/usbctl.1
+++ b/doc/usbctl.1
@@ -7,42 +7,42 @@ usbctl \- Linux-hardened deny_new_usb control
 .SH "DESCRIPTION"
 Control usb device and protection settings.
 .SH "COMMANDS"
-.PP 
+.PP
 \fIprotect\fR, \fIdisable\fR, \fIoff\fR
 .RS 4
 disallow new usb devices (protected)
 .RE
-.PP 
+.PP
 \fIunprotect\fR, \fIenable\fR, \fIon\fR
 .RS 4
 allow new usb devices (unprotected)
 .RE
-.PP 
-\fItemporary\fR, \fItemp\fR, \fItmp\fR
+.PP
+\fItemporary\fR, \fItemp\fR, \fItmp [seconds]\fR
 .RS 4
 temporarily disable protection (default 60 sec)
 .RE
-.PP 
+.PP
 \fIcheck\fR
 .RS 4
 exit with 1 if usb is unprotected
 .RE
-.PP 
+.PP
 \fIstatus\fR
 .RS 4
 print current protection status
 .RE
-.PP 
+.PP
 \fIlist\fR, \fIls\fR
 .RS 4
 list currently connected usb devices
 .RE
-.PP 
+.PP
 \fIlog\fR
 .RS 4
 display usb events in the kernel ring buffer
 .RE
-.PP 
+.PP
 \fIversion\fR
 .RS 4
 display version information and exit

--- a/usbctl
+++ b/usbctl
@@ -58,7 +58,7 @@ temporary() {
 	deny_new_usb 0
 	echo 'Press Ctrl-C to finish'
 	trap temporary_end INT TERM
-	for _ in $(seq ${TEMPORARY_WAIT}); do
+	for _ in $(seq "${TEMPORARY_WAIT}"); do
 		sleep 1
 		NEW_DEVICES=$(usb_list)
 		diff_usb_list "${OLD_DEVICES}" "${NEW_DEVICES}"

--- a/usbctl
+++ b/usbctl
@@ -5,7 +5,7 @@ VERSION="1.3-dev"
 SYSCTL_VAR=kernel.deny_new_usb
 NEW_DEVICES=
 OLD_DEVICES=
-TEMPORARY_WAIT=60
+TEMPORARY_WAIT=${2:-60}
 SUDO="sudo"
 
 if [[ ${EUID} -eq 0 ]]; then
@@ -17,14 +17,14 @@ usage() {
 	echo "Control usb device and protection settings."
 	echo
 	echo "COMMANDS:"
-	echo "  protect, disable, off -- disallow new usb devices (protected)"
-	echo "  unprotect, enable, on -- allow new usb devices (unprotected)"
-	echo "  temporary, temp, tmp  -- temporarily disable protection (default ${TEMPORARY_WAIT} sec)"
-	echo "  check                 -- exit with 1 if usb is unprotected"
-	echo "  status                -- print current protection status"
-	echo "  list, ls              -- list currently connected usb devices"
-	echo "  log                   -- display usb events in the kernel ring buffer"
-	echo "  version               -- display version information and exit"
+	echo "  protect, disable, off        -- disallow new usb devices (protected)"
+	echo "  unprotect, enable, on        -- allow new usb devices (unprotected)"
+	echo "  temporary, temp, tmp  [time] -- temporarily disable protection (default ${TEMPORARY_WAIT} sec)"
+	echo "  check                        -- exit with 1 if usb is unprotected"
+	echo "  status                       -- print current protection status"
+	echo "  list, ls                     -- list currently connected usb devices"
+	echo "  log                          -- display usb events in the kernel ring buffer"
+	echo "  version                      -- display version information and exit"
 }
 
 version() {


### PR DESCRIPTION
Hi,

A tiny PR to permit to select time for `usbctl tmp`, eg `usbctl tmp 10`.

Regards,