### PR TITLE
massive code cleanup. Should now be more legible

### DIFF
--- a/usbctl
+++ b/usbctl
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 
 VERSION="1.3-dev"
@@ -8,113 +9,126 @@ OLD_DEVICES=
 TEMPORARY_WAIT=60
 SUDO="sudo"
 
+BRIGHT_RED=$(tput setaf 1;tput bold)
+BRIGHT_GREEN=$(tput setaf 2;tput bold)
+NOCOLOR=$(tput sgr0)
+SELF_NAME=$(basename "$0")
+
+which pkexec &> /dev/null
+PK_EXISTS=${?}
+
 if [[ ${EUID} -eq 0 ]]; then
-	SUDO=""
+  SUDO=""
+ #elif [ ${PK_EXISTS} -eq 0 ];then # This will come later
+ # SUDO="pkexec"
 fi
 
 usage() {
-	echo "Usage: $(basename "$0") [COMMAND]"
-	echo "Control usb device and protection settings."
-	echo
-	echo "COMMANDS:"
-	echo "  protect, disable, off -- disallow new usb devices (protected)"
-	echo "  unprotect, enable, on -- allow new usb devices (unprotected)"
-	echo "  temporary, temp, tmp  -- temporarily disable protection (default ${TEMPORARY_WAIT} sec)"
-	echo "  check                 -- exit with 1 if usb is unprotected"
-	echo "  status                -- print current protection status"
-	echo "  list, ls              -- list currently connected usb devices"
-	echo "  log                   -- display usb events in the kernel ring buffer"
-	echo "  version               -- display version information and exit"
+  cat 1>&2 << EOF
+Usage: ${SELF_NAME} [COMMAND]
+Control usb device and protection settings.
+
+COMMANDS:
+  protect, disable, off -- disallow new usb devices (protected)
+  unprotect, enable, on -- allow new usb devices (unprotected)
+  temporary, temp, tmp  -- temporarily disable protection (default ${TEMPORARY_WAIT} sec)
+  check                 -- exit with 1 if usb is unprotected
+  status                -- print current protection status
+  list, ls              -- list currently connected usb devices
+  log                   -- display usb events in the kernel ring buffer
+  version               -- display version information and exit
+
+EOF
+  exit 2
 }
 
 version() {
-	echo "$(basename "$0") ${VERSION}"
+  echo "${SELF_NAME} ${VERSION}"
 }
 
 deny_new_usb() {
-	${SUDO} sysctl -q "${SYSCTL_VAR}=${1}"
-	usb_status
+  ${SUDO} sysctl -q "${SYSCTL_VAR}=${1}"
+  usb_status
 }
 
 usb_protected() {
-	sysctl -n "${SYSCTL_VAR}"|grep -q 1
+  sysctl -n "${SYSCTL_VAR}"|grep -q 1
 }
 
 usb_status() {
-	if usb_protected; then
-		printf '\e[32;1m'
-	else
-		printf '\e[31;1mUN'
-	fi
-	printf 'PROTECTED\e[0m\n'
+  if usb_protected; then
+    echo "${BRIGHT_GREEN}PROTECTED${NO_COLOR}"
+   else
+    echo "${BRIGHT_RED}UNPROTECTED${NO_COLOR}"
+  fi
 }
 
 usb_list() {
-	lsusb -t
+  lsusb -t
 }
 
 temporary() {
-	OLD_DEVICES=$(usb_list)
-	deny_new_usb 0
-	echo 'Press Ctrl-C to finish'
-	trap temporary_end INT TERM
-	for _ in $(seq ${TEMPORARY_WAIT}); do
-		sleep 1
-		NEW_DEVICES=$(usb_list)
-		diff_usb_list "${OLD_DEVICES}" "${NEW_DEVICES}"
-		OLD_DEVICES="${NEW_DEVICES}"
-	done
-	temporary_end
+  OLD_DEVICES=$(usb_list)
+  deny_new_usb 0
+  echo 'Press Ctrl-C to finish'
+  trap temporary_end INT TERM
+  for i in $(seq ${TEMPORARY_WAIT}); do
+    sleep 1
+    NEW_DEVICES=$(usb_list)
+    diff_usb_list "${OLD_DEVICES}" "${NEW_DEVICES}"
+    OLD_DEVICES="${NEW_DEVICES}"
+  done
+  temporary_end
 }
 
 temporary_end() {
-	deny_new_usb 1
-	diff_usb_list "${OLD_DEVICES}" "$(usb_list)"
-	exit
+  deny_new_usb 1
+  diff_usb_list "${OLD_DEVICES}" "$(usb_list)"
+  exit
 }
 
 diff_usb_list() {
-	local OLD_DEVICES="${1}"
-	local NEW_DEVICES="${2}"
-	diff --color <(printf "%s" "${OLD_DEVICES}") <(printf "%s" "${NEW_DEVICES}") ||:
+  local OLD_DEVICES="${1}"
+  local NEW_DEVICES="${2}"
+  diff --color <(printf "%s" "${OLD_DEVICES}") <(printf "%s" "${NEW_DEVICES}") ||:
 }
 
 usb_log() {
-	DMESG=dmesg
-	if sysctl -n kernel.dmesg_restrict | grep -q 1; then
-		DMESG="${SUDO} ${DMESG}"
-	fi
-	${DMESG} --color="${USBCTL_LOG_COLOR:-always}" --ctime|grep -i usb --color="${USBCTL_GREP_COLOR:-never}"
+  DMESG=dmesg
+  if sysctl -n kernel.dmesg_restrict | grep -q 1; then
+    DMESG="${SUDO} ${DMESG}"
+  fi
+  ${DMESG} --color="${USBCTL_LOG_COLOR:-always}" --ctime|grep -i usb --color="${USBCTL_GREP_COLOR:-never}"
 }
 
 case "$1" in
-	on|enable|unprotect)
-		deny_new_usb 0
-		;;
-	off|disable|protect)
-		deny_new_usb 1
-		;;
-	temporary|tmp|temp)
-		temporary
-		;;
-	check)
-		usb_protected
-		;;
-	status)
-		usb_status
-		;;
-	list|ls)
-		usb_list
-		;;
-	log)
-		usb_log
-		;;
-	version|--version)
-		version
-		;;
-	*)
-		usage
-		;;
+  on|enable|unprotect)
+    deny_new_usb 0
+    ;;
+  off|disable|protect)
+    deny_new_usb 1
+    ;;
+  temporary|tmp|temp)
+    temporary
+    ;;
+  check)
+    usb_protected
+    ;;
+  status)
+    usb_status
+    ;;
+  list|ls)
+    usb_list
+    ;;
+  log)
+    usb_log
+    ;;
+  version|--version)
+    version
+    ;;
+  *)
+    usage
+    ;;
 esac
 
 # vim:set noet:


### PR DESCRIPTION
Fixed some terribad code hygiene

Not sure whoever told you this was acceptable. This is how malware is written to be unreadable.

```
	if usb_protected; then
		printf '\e[32;1m'
	else
		printf '\e[31;1mUN'
	fi
	printf 'PROTECTED\e[0m\n'
```